### PR TITLE
Add contract addresses and remix example to documentation 

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,25 @@ You can also omit the timestamp and only read the value.
 DATA_FEED_ID=0x01aadef3e56974c0ed8829b34353495191c1362f48bb5aa9533835c00cb2a7af yarn run:read-value-with-id
 ```
 
+## Testing with Remix
+Deploy [DataFeedReaderExample](./contracts/DataFeedReaderExample.sol) using Remix by inputing the DapiServer contract address as the constructor argument.
+
+Once deployed, whitelist the deployed `DataFeedReaderExample` contract address on the `SelfServeDapiServerWhitelister` [here](https://mumbai.polygonscan.com/address/0x78D95f27B068F36Bd4c3f29e424D7072D149DDF3#writeContract).
+
+To be able to read via a `datafeedId`, whitelist by calling the `allowToReadDataFeedWithIdFor30Days` function with the `datafeedId` and `reader` address (DataFeedReaderExample).
+
+To be able to read via a `dAPI Name`, whitelist by calling the `allowToReadDataFeedWithDapiNameFor30Days` function with the `dapiName` and `reader` address (DataFeedReaderExample).
+
+Note: The dapiName argument has to be a bytes32 character, you can use the following cli commands to convert a string to bytes32
+
+```
+/home/data-feed-reader-example> npm install -g @ethersproject/cli
+/home/data-feed-reader-example> ethers eval 'utils.formatBytes32String("BTC/USD")'
+0x4254432f55534400000000000000000000000000000000000000000000000000
+```
+
+After Whitelisting, head back to remix and try calling `readDataFeedWithDapiName` or `readDataFeedWithId` with the whitelisted dapiName/datafeedId. Your deployed `DataFeedReaderExample` should display a value and timestamp associated with the respective dapiName/datafeedId.
+
 ## Local development and testing
 
 A MockDapiServer contract is provided for local development and testing. See the tests for its usage, and run the tests

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ that you can call to allow your contract to do on-chain reads for free for testi
 
 ## Contracts
 
-The contract addresses for `DapiServer` and `SelfServeDapiServerWhitelister` for polygon testnet can be found
+The contract addresses for `DapiServer` and `SelfServeDapiServerWhitelister` for Polygon Testnet can be found
 [here](https://docs.api3.org/dapis/reference/chains.html). The cli commands used to whitelist and read datafeeds
 reference these addresses to execute scripts in `/scripts`.
 

--- a/README.md
+++ b/README.md
@@ -20,11 +20,17 @@ We duplicated all of our data feeds across all mainnets on the Polygon testnet, 
 faucet and RPC endpoints are reliable. Extending this to other testnets is not trivial, which is why we are not planning
 to do so in the foreseeable future.
 
+### Contract Addresses
+```
+DapiServer: 0x71Da7A936fCaEd1Ee364Df106B12deF6D1Bf1f14
+SelfServeDapiServerWhitelister: 0x78D95f27B068F36Bd4c3f29e424D7072D149DDF3
+```
+
 ## Access control
 
 Anyone can read an API3 data feed with an off-chain, static call. However, only contracts allowed by an authorized
 account are allowed to read on-chain. For production use-cases on mainnet, you will need to pay for contract read
-access. On Polygon testnet, there is a contract that you can call to allow your contract to do on-chain reads for free
+access. On Polygon testnet, there is a contract called [`SelfServeDapiServerWhitelister`](https://mumbai.polygonscan.com/address/0x78D95f27B068F36Bd4c3f29e424D7072D149DDF3#writeContract) that you can call to allow your contract to do on-chain reads for free
 for testing purposes, which we use in this repo.
 
 ## dAPI names and data feed IDs

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ faucet and RPC endpoints are reliable. Extending this to other testnets is not t
 to do so in the foreseeable future.
 
 ### Contract Addresses
+
 ```
 DapiServer: 0x71Da7A936fCaEd1Ee364Df106B12deF6D1Bf1f14
 SelfServeDapiServerWhitelister: 0x78D95f27B068F36Bd4c3f29e424D7072D149DDF3
@@ -30,8 +31,9 @@ SelfServeDapiServerWhitelister: 0x78D95f27B068F36Bd4c3f29e424D7072D149DDF3
 
 Anyone can read an API3 data feed with an off-chain, static call. However, only contracts allowed by an authorized
 account are allowed to read on-chain. For production use-cases on mainnet, you will need to pay for contract read
-access. On Polygon testnet, there is a contract called [`SelfServeDapiServerWhitelister`](https://mumbai.polygonscan.com/address/0x78D95f27B068F36Bd4c3f29e424D7072D149DDF3#writeContract) that you can call to allow your contract to do on-chain reads for free
-for testing purposes, which we use in this repo.
+access. On Polygon testnet, there is a contract called
+[`SelfServeDapiServerWhitelister`](https://mumbai.polygonscan.com/address/0x78D95f27B068F36Bd4c3f29e424D7072D149DDF3#writeContract)
+that you can call to allow your contract to do on-chain reads for free for testing purposes, which we use in this repo.
 
 ## dAPI names and data feed IDs
 
@@ -125,15 +127,21 @@ DATA_FEED_ID=0x01aadef3e56974c0ed8829b34353495191c1362f48bb5aa9533835c00cb2a7af 
 ```
 
 ## Testing with Remix
-Deploy [DataFeedReaderExample](./contracts/DataFeedReaderExample.sol) using Remix by inputing the DapiServer contract address as the constructor argument.
 
-Once deployed, whitelist the deployed `DataFeedReaderExample` contract address on the `SelfServeDapiServerWhitelister` [here](https://mumbai.polygonscan.com/address/0x78D95f27B068F36Bd4c3f29e424D7072D149DDF3#writeContract).
+Deploy [DataFeedReaderExample](./contracts/DataFeedReaderExample.sol) using Remix by inputing the DapiServer contract
+address as the constructor argument.
 
-To be able to read via a `datafeedId`, whitelist by calling the `allowToReadDataFeedWithIdFor30Days` function with the `datafeedId` and `reader` address (DataFeedReaderExample).
+Once deployed, whitelist the deployed `DataFeedReaderExample` contract address on the `SelfServeDapiServerWhitelister`
+[here](https://mumbai.polygonscan.com/address/0x78D95f27B068F36Bd4c3f29e424D7072D149DDF3#writeContract).
 
-To be able to read via a `dAPI Name`, whitelist by calling the `allowToReadDataFeedWithDapiNameFor30Days` function with the `dapiName` and `reader` address (DataFeedReaderExample).
+To be able to read via a `datafeedId`, whitelist by calling the `allowToReadDataFeedWithIdFor30Days` function with the
+`datafeedId` and `reader` address (DataFeedReaderExample).
 
-Note: The dapiName argument has to be a bytes32 character, you can use the following cli commands to convert a string to bytes32
+To be able to read via a `dAPI Name`, whitelist by calling the `allowToReadDataFeedWithDapiNameFor30Days` function with
+the `dapiName` and `reader` address (DataFeedReaderExample).
+
+Note: The dapiName argument has to be a bytes32 character, you can use the following cli commands to convert a string to
+bytes32
 
 ```
 /home/data-feed-reader-example> npm install -g @ethersproject/cli
@@ -141,7 +149,9 @@ Note: The dapiName argument has to be a bytes32 character, you can use the follo
 0x4254432f55534400000000000000000000000000000000000000000000000000
 ```
 
-After Whitelisting, head back to remix and try calling `readDataFeedWithDapiName` or `readDataFeedWithId` with the whitelisted dapiName/datafeedId. Your deployed `DataFeedReaderExample` should display a value and timestamp associated with the respective dapiName/datafeedId.
+After Whitelisting, head back to remix and try calling `readDataFeedWithDapiName` or `readDataFeedWithId` with the
+whitelisted dapiName/datafeedId. Your deployed `DataFeedReaderExample` should display a value and timestamp associated
+with the respective dapiName/datafeedId.
 
 ## Local development and testing
 

--- a/README.md
+++ b/README.md
@@ -20,12 +20,7 @@ We duplicated all of our data feeds across all mainnets on the Polygon testnet, 
 faucet and RPC endpoints are reliable. Extending this to other testnets is not trivial, which is why we are not planning
 to do so in the foreseeable future.
 
-### Contract Addresses
-
-```
-DapiServer: 0x71Da7A936fCaEd1Ee364Df106B12deF6D1Bf1f14
-SelfServeDapiServerWhitelister: 0x78D95f27B068F36Bd4c3f29e424D7072D149DDF3
-```
+The contract addresses for `DapiServer` and `SelfServeDapiServerWhitelister` for polygon testnet can be found [here](https://docs.api3.org/dapis/reference/chains.html). The cli commands used to whitelist and read datafeeds reference the addresses to execute scripts in `/scripts`.
 
 ## Access control
 
@@ -128,7 +123,7 @@ DATA_FEED_ID=0x01aadef3e56974c0ed8829b34353495191c1362f48bb5aa9533835c00cb2a7af 
 
 ## Testing with Remix
 
-Deploy [DataFeedReaderExample](./contracts/DataFeedReaderExample.sol) using Remix by inputing the DapiServer contract
+Deploy [DataFeedReaderExample](./contracts/DataFeedReaderExample.sol) using Remix by inputting the DapiServer contract
 address as the constructor argument.
 
 Once deployed, whitelist the deployed `DataFeedReaderExample` contract address on the `SelfServeDapiServerWhitelister`
@@ -137,7 +132,7 @@ Once deployed, whitelist the deployed `DataFeedReaderExample` contract address o
 To be able to read via a `datafeedId`, whitelist by calling the `allowToReadDataFeedWithIdFor30Days` function with the
 `datafeedId` and `reader` address (DataFeedReaderExample).
 
-To be able to read via a `dAPI Name`, whitelist by calling the `allowToReadDataFeedWithDapiNameFor30Days` function with
+To be able to read via a `dapiName`, whitelist by calling the `allowToReadDataFeedWithDapiNameFor30Days` function with
 the `dapiName` and `reader` address (DataFeedReaderExample).
 
 Note: The dapiName argument has to be a bytes32 character, you can use the following cli commands to convert a string to

--- a/README.md
+++ b/README.md
@@ -20,7 +20,9 @@ We duplicated all of our data feeds across all mainnets on the Polygon testnet, 
 faucet and RPC endpoints are reliable. Extending this to other testnets is not trivial, which is why we are not planning
 to do so in the foreseeable future.
 
-The contract addresses for `DapiServer` and `SelfServeDapiServerWhitelister` for polygon testnet can be found [here](https://docs.api3.org/dapis/reference/chains.html). The cli commands used to whitelist and read datafeeds reference the addresses to execute scripts in `/scripts`.
+The contract addresses for `DapiServer` and `SelfServeDapiServerWhitelister` for polygon testnet can be found
+[here](https://docs.api3.org/dapis/reference/chains.html). The cli commands used to whitelist and read datafeeds
+reference the addresses to execute scripts in `/scripts`.
 
 ## Access control
 

--- a/README.md
+++ b/README.md
@@ -20,10 +20,6 @@ We duplicated all of our data feeds across all mainnets on the Polygon testnet, 
 faucet and RPC endpoints are reliable. Extending this to other testnets is not trivial, which is why we are not planning
 to do so in the foreseeable future.
 
-The contract addresses for `DapiServer` and `SelfServeDapiServerWhitelister` for polygon testnet can be found
-[here](https://docs.api3.org/dapis/reference/chains.html). The cli commands used to whitelist and read datafeeds
-reference the addresses to execute scripts in `/scripts`.
-
 ## Access control
 
 Anyone can read an API3 data feed with an off-chain, static call. However, only contracts allowed by an authorized
@@ -31,6 +27,12 @@ account are allowed to read on-chain. For production use-cases on mainnet, you w
 access. On Polygon testnet, there is a contract called
 [`SelfServeDapiServerWhitelister`](https://mumbai.polygonscan.com/address/0x78D95f27B068F36Bd4c3f29e424D7072D149DDF3#writeContract)
 that you can call to allow your contract to do on-chain reads for free for testing purposes, which we use in this repo.
+
+## Contracts
+
+The contract addresses for `DapiServer` and `SelfServeDapiServerWhitelister` for polygon testnet can be found
+[here](https://docs.api3.org/dapis/reference/chains.html). The cli commands used to whitelist and read datafeeds
+reference these addresses to execute scripts in `/scripts`.
 
 ## dAPI names and data feed IDs
 


### PR DESCRIPTION
I added a remix deployment section, to be able to quickly deploy and test the Data-feed-reader example. Also added the contract addresses for polygon-testnet for `SelfServeDapiServerWhitelister` and `DapiServer`.