### PR TITLE
Removes testnet chains that are no longer supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,24 +61,16 @@ See https://github.com/api3dao/chains for details
 
 ### Testnets
 
-- arbitrum-goerli-testnet
 - avalanche-testnet
 - blast-sepolia-testnet
 - bsc-testnet
-- cronos-testnet
-- ethereum-goerli-testnet
 - ethereum-sepolia-testnet
 - fantom-testnet
 - gnosis-testnet
 - kava-testnet
-- linea-goerli-testnet
-- mantle-goerli-testnet
 - moonbeam-testnet
 - oev-network-sepolia-testnet
-- optimism-goerli-testnet
 - polygon-testnet
-- polygon-zkevm-goerli-testnet
-- rsk-testnet
 
 ## Local development and testing
 


### PR DESCRIPTION
Removes references to no longer supported testnets. See [here](https://github.com/api3dao/tasks/issues/823)