### PR TITLE
fix: drop now-unnecessary --ignore-engines

### DIFF
--- a/.github/workflows/ continuous-build.yml
+++ b/.github/workflows/ continuous-build.yml
@@ -10,13 +10,13 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
-      - run: yarn --ignore-engines
+      - run: yarn
       - run: yarn lint
       - run: yarn test
   check-md-links:
     runs-on: ubuntu-latest
     steps:
-    - name: Check out repo
-      uses: actions/checkout@v4
-    - name: Check Markdown links
-      uses: gaurav-nelson/github-action-markdown-link-check@v1
+      - name: Check out repo
+        uses: actions/checkout@v4
+      - name: Check Markdown links
+        uses: gaurav-nelson/github-action-markdown-link-check@v1

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 - Install dependencies
 
 ```sh
-yarn --ignore-engines
+yarn
 ```
 
 - Create a `.env` file similar to `example.env`


### PR DESCRIPTION
Closes #199 now that `@api3/dapi-management` is updated to use Airnode v0.15 via https://github.com/api3dao/data-feeds/pull/2421, https://github.com/api3dao/data-feeds/pull/2430, and https://github.com/api3dao/signed-api/pull/417